### PR TITLE
Add no op jobs

### DIFF
--- a/.circleci/continued_config.yml
+++ b/.circleci/continued_config.yml
@@ -77,7 +77,6 @@ workflows:
     jobs:
       - the_stand_in:
           name: "Alpha Workflow Complete"
-          quadrant: "alpha"
   delta-quadrant:
     when: << pipeline.parameters.delta >>
     jobs:
@@ -105,7 +104,6 @@ workflows:
     jobs:
       - the_stand_in:
           name: "Delta Workflow Complete"
-          quadrant: "delta"
   gamma-quadrant:
     when: << pipeline.parameters.gamma >>
     jobs:
@@ -133,4 +131,3 @@ workflows:
     jobs:
       - the_stand_in:
           name: "Gamma Workflow Complete"
-          quadrant: "gamma"

--- a/.circleci/continued_config.yml
+++ b/.circleci/continued_config.yml
@@ -47,17 +47,7 @@ jobs:
           name: "Completed << parameters.quadrant >> workflow"
           command: echo "The << parameters.quadrant >> workflow has completed successfully"
   the_stand_in:
-    executor: base
-    parameters:
-      quadrant:
-        type: string
-        default: ""
-    steps:
-      - run:
-          name: Stand in for << parameters.quadrant >> workflow
-          command: |
-            echo "Stand in for << parameters.quadrant >> quadrant workflow \n
-             marking complete for github checks"
+    type: no-op
 
 workflows:
   alpha-quadrant:

--- a/README.md
+++ b/README.md
@@ -22,13 +22,12 @@ This can be simplified further by having a single job at the end of each workflo
 
 - Easy to implement
 - Prevents human error by being fully automated
-- Stand-in job can use a smaller resource class than the normal jobs
+- Stand-in job can be configured as a [no-op job](https://circleci.com/docs/configuration-reference/#job-type) to remove the need to spin up compute to satisfy the check
 - Stand-in workflow and job make it clear what is happening in both the UI and the CircleCI config
 - Setup config can be locked down with [config policies](https://circleci.com/docs/config-policy-management-overview/)
 
 ### Cons
 
-- Requires a job to be spun up to satisfy the check
 - Increases status check management overhead if workflow cannot be fanned back into a single or a small amount of jobs
 
 ## Demo
@@ -96,3 +95,4 @@ Any parameters that were _not_ set to `true` have a stand-in parameter set to `t
 - [CircleCI's Dynamic Config](https://circleci.com/docs/dynamic-config/)
 - [CircleCI Feature Request to Better Support Status Checks](https://ideas.circleci.com/cloud-feature-requests/p/support-utilizing-checks-with-dynamic-configs)
 - [Alternative Workaround: Exiting early](https://github.com/kelvintaywl-cci/dynamic-config-showcase/tree/main)
+- [no-op Job Type](https://circleci.com/docs/configuration-reference/#job-type)


### PR DESCRIPTION
Convert stand in jobs to no-op to remove wasted compute time.

Update the readme to include no-op job information